### PR TITLE
Add test to compare with built-in function at s=0

### DIFF
--- a/Tests/SpinWeightedSpheroidalHarmonics.wlt
+++ b/Tests/SpinWeightedSpheroidalHarmonics.wlt
@@ -12,5 +12,18 @@ VerificationTest[
 VerificationTest[
         SpinWeightedSpheroidalEigenvalue[2, 10, 10, 1.2345],
         79.76477183487565,
-        TestID -> "SpinWeightedSpheroidalEigenvalue with positive spheroidicity",
+        TestID -> "SpinWeightedSpheroidalEigenvalue with positive spheroidicity"
 ]
+
+Module[{l=2,m=2,c=SetPrecision[8.58583+1.98352 I,50]}, VerificationTest[
+        N[SpheroidalEigenvalue[l, m, c],10],
+        N[SpinWeightedSpheroidalEigenvalue[0, l, m, I*c] + 2*m*I*c,10],
+        TestID -> "SpinWeightedSpheroidalEigenvalue with s=0 against built-in Mathematica function"
+]]
+
+Module[{l=2,m=2,c=SetPrecision[2.28831+5.351950 I,50]}, VerificationTest[
+        N[SpheroidalEigenvalue[l, m, c],10],
+        N[SpinWeightedSpheroidalEigenvalue[0, l, m, I*c] + 2*m*I*c,10],
+        TestID -> "SpinWeightedSpheroidalEigenvalue with s=0 against built-in Mathematica function"
+]]
+


### PR DESCRIPTION
Certain values work great (i.e. comparison conventions is most likely fine) but some don't match without warning (added test example  for both cases). (UPDATE: different choice  of branch remove as unit test)