### PR TITLE
Add support for extracting expansion coefficients from a SpinWeightedSpheroidalHarmonicSFunction

### DIFF
--- a/Kernel/SpinWeightedSpheroidalHarmonics.m
+++ b/Kernel/SpinWeightedSpheroidalHarmonics.m
@@ -538,6 +538,14 @@ SpinWeightedSpheroidalHarmonicSFunction /:
 
 
 (* ::Subsection::Closed:: *)
+(*Expansion coefficients*)
+
+
+SpinWeightedSpheroidalHarmonicSFunction[s_Integer, l_Integer, m_Integer, \[Gamma]_?InexactNumberQ, {method_String, coeffs_List, nDown_Integer, nUp_Integer}]["ExpansionCoefficients"] :=
+  Thread[Range[-nDown, nUp] -> coeffs];
+
+
+(* ::Subsection::Closed:: *)
 (*Numerical evaluation*)
 
 

--- a/Kernel/SpinWeightedSpheroidalHarmonics.m
+++ b/Kernel/SpinWeightedSpheroidalHarmonics.m
@@ -542,7 +542,7 @@ SpinWeightedSpheroidalHarmonicSFunction /:
 
 
 SpinWeightedSpheroidalHarmonicSFunction[s_Integer, l_Integer, m_Integer, \[Gamma]_?InexactNumberQ, {method_String, coeffs_List, nDown_Integer, nUp_Integer}]["ExpansionCoefficients"] :=
-  Thread[Range[-nDown, nUp] -> coeffs];
+  Association[Thread[Range[-nDown, nUp] -> coeffs]];
 
 
 (* ::Subsection::Closed:: *)

--- a/Source/Documentation/English/ReferencePages/Symbols/SpinWeightedSpheroidalHarmonicSFunction.md
+++ b/Source/Documentation/English/ReferencePages/Symbols/SpinWeightedSpheroidalHarmonicSFunction.md
@@ -7,7 +7,8 @@
     },
   "Numerical Evaluation" -> {
     "Slm = SpinWeightedSpheroidalHarmonicS[-2, 2, 2, 0.1`32]",
-    "Slm[\[Pi]/4, 0]"
+    "Slm[\[Pi]/4, 0]",
+    "Slm[\"ExpansionCoefficients\"]"
     },
   "See Also" -> {"SpinWeightedSpheroidalHarmonicS"},
   "More About" -> {"SpinWeightedSpheroidalHarmonics"},

--- a/Tests/SpinWeightedSpheroidalHarmonics.wlt
+++ b/Tests/SpinWeightedSpheroidalHarmonics.wlt
@@ -420,6 +420,22 @@ VerificationTest[
   TestID->"SpinWeightedSpheroidalHarmonicS[...] with 0.0``32 spheroidicity"
 ]
 
+With[{s = 2, l = 10, m = 2, \[Gamma] = 0.1}, 
+  VerificationTest[
+    SetAccuracy[SpinWeightedSpheroidalHarmonicS[s, l, m, \[Gamma]]["ExpansionCoefficients"][[1;;5]], 6],
+    <|0 -> -8.818050086267075, 1 -> 21.65089643682929, 2 -> -17.171313724018557, 
+      3 -> 4.847739931702922, 4 -> -0.2937583721632349|>,
+    TestID -> "ExpansionCoefficients (Leaver)"
+  ]
+
+  VerificationTest[
+    SetAccuracy[SpinWeightedSpheroidalHarmonicS[s, l, m, \[Gamma], Method -> "SphericalExpansion"]["ExpansionCoefficients"][[2;;6]], 6],
+    <|-2 -> 0.000055654127758144056, -1 -> -0.0169795873354771, 0 -> 0.9997443511214629, 
+      1 -> 0.014929457524949523, 2 -> 0.00018496617816892035|>,
+    TestID -> "ExpansionCoefficients (SphericalExpansion)"
+  ]
+]
+
 EndTestSection[]
 
 BeginTestSection["Complex spheroidicity near expected QNM values"]


### PR DESCRIPTION
This adds support for getting the expansion coefficients from a SpinWeightedSpheroidalHarmonicSFunction. Example usage:
```Mathematica
S = SpinWeightedSpheroidalHarmonicS[s, l, m, \[Gamma]];
S["ExpansionCoefficients"]
```
This returns a List of the form `{i -> coeff[[i]], ...}` where i is the index in the expansion. This addresses issue #27.